### PR TITLE
Handle non-OK responses from GitHub API

### DIFF
--- a/lib/mix_helpers.ex
+++ b/lib/mix_helpers.ex
@@ -7,7 +7,13 @@ defmodule MixHelpers do
   Fetches the contents of the given `path` using the GitHub API.
   """
   def fetch_gh_contents!("https://api.github.com/repos" <> _ = path) do
-    Req.get!(path).body
+    case Req.get!(path) do
+      %{status: 200} = response ->
+        response.body
+
+      error_response ->
+        raise("received non-OK response: #{inspect(error_response, pretty: true)}")
+    end
   end
 
   @doc """


### PR DESCRIPTION
This should primarily address the problem where rate-limiting responses cause `MixHelpers.fetch_gh_contents!` to return a different body which breaks other functions. After this update, the fetch function would be the one to raise, which makes the errors more informative.

Fixes #7 (at least for the time being)