### PR TITLE
Add module ordering + refactor

### DIFF
--- a/lib/mix/helpers/io.ex
+++ b/lib/mix/helpers/io.ex
@@ -1,0 +1,59 @@
+defmodule Mix.Helpers.IO do
+  @moduledoc """
+  Helper functions for console IO messages and user prompts.
+  """
+
+  @doc """
+  Prints a message based on the fetch result.
+
+  The second argument `available_modules` is needed to list the modules for the
+  user in the case where an invalid command or module name is provided.
+  """
+  def print_result_message({:ok, :fetched}, _available_modules),
+    do: Mix.Shell.IO.info("Exercises generated. Good luck!")
+
+  def print_result_message({:ok, :complete}, _available_modules),
+    do: Mix.Shell.IO.info("Nothing to generate. You have all available exercises!")
+
+  def print_result_message({:error, :aborted}, _available_modules),
+    do: Mix.Shell.IO.info("Aborted")
+
+  def print_result_message({:error, _}, available_modules),
+    do: Mix.Helpers.IO.print_options(available_modules)
+
+  @doc """
+  Prompts the user to download the next module. Returns a boolean.
+  """
+  def confirm_download?(next_module) do
+    Mix.Shell.IO.info(
+      "Based on what you have saved in your project, " <>
+        "the next module to fetch is:\n\n#{next_module}\n"
+    )
+
+    Mix.Shell.IO.yes?("Proceed to generate exercises for this module?")
+  end
+
+  @doc """
+  Prints an error message with the available modules to fetch.
+  """
+  def print_options(available_modules) do
+    info_block_output()
+
+    Mix.Shell.IO.info("Available options are:\n")
+    Enum.map(available_modules, &Mix.Shell.IO.info/1)
+    Mix.Shell.IO.info("")
+  end
+
+  defp info_block_output() do
+    Mix.Shell.IO.error("** Error: invalid command")
+
+    Mix.Shell.IO.info("""
+
+    Spirit Gen needs to run with one string argument for the exercise to download
+    Each string argument should be snake case
+    Either no arg was provided or there was no match
+
+    Example: basic_types
+    """)
+  end
+end

--- a/lib/mix_helpers.ex
+++ b/lib/mix_helpers.ex
@@ -48,4 +48,18 @@ defmodule MixHelpers do
     fetch_gh_contents!(url)
     |> Enum.map(&download_content_object/1)
   end
+
+  @doc """
+  Lists all module names in the same order as the official guide.
+  """
+  def list_all_modules() do
+    [
+      "basic_types",
+      "lists_and_tuples",
+      "pattern_matching",
+      "case_cond_and_if",
+      "anonymous_functions",
+      "binaries_strings_and_charlists"
+    ]
+  end
 end


### PR DESCRIPTION
This PR adds upgrades `spirit.gen` to be aware of the correct ordering (per the getting started guide) of the modules in the exercise repo.

- The mix task looks for `module_list.txt` in the exercise repo and uses it to identify the correct order of the modules.
- Running `mix spirit.gen` without arguments will now scan the project and detect the next exercise module to be fetched.
- In case of bad commands or wrong module names, the task will now print the module list in the correct order.

The reliance on a text file in the exercise repo makes it a little easier to integrate more exercise repos in the future.